### PR TITLE
Pass float32 values into K3D

### DIFF
--- a/glue_k3d/scatter/layer_artist.py
+++ b/glue_k3d/scatter/layer_artist.py
@@ -77,7 +77,7 @@ class K3DScatterLayerArtist(LayerArtist):
            self.layer[self._viewer_state.x_att], 
            self.layer[self._viewer_state.y_att], 
            self.layer[self._viewer_state.z_att], 
-        ]).transpose()
+        ]).transpose().astype(np.float32)
 
     def _update_data(self):
 
@@ -131,7 +131,7 @@ class K3DScatterLayerArtist(LayerArtist):
             s *= (45 * self.state.size_scaling)
             s[np.isnan(s)] = 0
 
-            options["point_sizes"] = s
+            options["point_sizes"] = s.astype(np.float32)
 
         return points(**options)
 

--- a/glue_k3d/volume/layer_artist.py
+++ b/glue_k3d/volume/layer_artist.py
@@ -67,7 +67,7 @@ class K3DVolumeLayerArtist(LayerArtist):
         data = self._data_proxy.compute_fixed_resolution_buffer(bounds=self._viewer_state._bounds())
         data = (data - self.state.vmin) / (self.state.vmax - self.state.vmin)
         data[np.isnan(data)] = 0
-        return np.clip(data, 0, 1)
+        return np.clip(data, 0, 1).astype(np.float32)
 
     def _create_volume(self):
 
@@ -77,7 +77,7 @@ class K3DVolumeLayerArtist(LayerArtist):
             cmap = linear_color_map(self.state.cmap)
 
         options = dict(
-            volume=np.ndarray((0,0,0)),
+            volume=np.ndarray((0,0,0)).astype(np.float32),
             color_map=cmap,
             color_range=(0, 1),
             alpha_coef=100 * self.state.alpha,


### PR DESCRIPTION
K3D wants `float32` values and will raise a warning (and create a copy) when it doesn't get them. Thus, this PR updates our layer artists to pass `float32` arrays into K3D.