### PR TITLE
Make plot respect glue color settings

### DIFF
--- a/glue_k3d/scatter/viewer.py
+++ b/glue_k3d/scatter/viewer.py
@@ -1,3 +1,4 @@
+from echo import CallbackProperty
 from glue_jupyter.common.state3d import Scatter3DViewerState
 from glue_vispy_viewers.scatter.jupyter.viewer_state_widget import Scatter3DViewerStateWidget
 
@@ -7,7 +8,7 @@ from glue_k3d.scatter.layer_state_widget import Scatter3DLayerStateWidget
 
 
 class K3DScatterViewerState(Scatter3DViewerState):
-    pass
+    visible_grid = CallbackProperty(True) 
 
 
 class K3DScatterView(K3DBaseView):

--- a/glue_k3d/utils.py
+++ b/glue_k3d/utils.py
@@ -1,9 +1,11 @@
 import numpy as np
-from matplotlib.colors import Normalize
+from matplotlib.colors import Normalize, cnames
 from glue.utils import ensure_numerical
 
 
 def to_hex_int(color):
+    if not color.startswith("#"):
+        color = cnames.get(color, "#ffffff")
     return int(color[1:], 16)
 
 
@@ -29,6 +31,7 @@ def rgba_hex_to_rgb_hex(color):
 def hex_to_rgb(hex_color):
     hex_color = hex_color.lstrip('#')
     return tuple(int(hex_color[2*i:2*i+2], 16) for i in range(3))
+
 
 def fixed_color(layer_state):
     layer_color = layer_state.color

--- a/glue_k3d/volume/viewer.py
+++ b/glue_k3d/volume/viewer.py
@@ -15,6 +15,7 @@ from glue_k3d.volume.viewer_state_widget import K3DVolumeViewerStateWidget
 
 class K3DVolumeViewerState(VolumeViewerState):
 
+    visible_grid = CallbackProperty(True)
     resolution = CallbackProperty(256)
     reference_data = SelectionCallbackProperty(docstring='The dataset that is used to define the '
                                                          'available pixel/world components, and '


### PR DESCRIPTION
This PR makes the figure colors respect the glue color settings:
* The figure background color will match `BACKGROUND_COLOR`
* The grid and axis label colors will match `FOREGROUND_COLOR`

Additionally, this exposes the ability to show/hide the grid from the viewer state.