### PR TITLE
Support other snapshot types

### DIFF
--- a/glue_k3d/utils.py
+++ b/glue_k3d/utils.py
@@ -148,11 +148,15 @@ def save_snapshot(figure, filepath):
         display: none !important;
     }
     """
-    head = soup.find("head")
-    if head:
-        head.append(style)
+
+    if figure.snapshot_type == "inline":
+        root = soup.find("div")
     else:
-        soup.html.append(style)
+        root = soup.find("head")
+        if not root:
+            root = soup.html
+
+    root.append(style)
     html = soup.prettify()
 
     with open(filepath, "w") as f:


### PR DESCRIPTION
This PR updates our `save_snapshot` utility to support saving `inline` and `online` snapshots as well.

Note that we don't actually use this at all (yet) in the export tool, this PR only touches the utility function.