### PR TITLE
Hide axes helper

### DIFF
--- a/glue_k3d/common/figure.py
+++ b/glue_k3d/common/figure.py
@@ -31,4 +31,5 @@ def create_plot(state):
         grid_color=fg_color,
         grid_visible=visible_grid,
         camera_mode="orbit",
+        axes_helper=0.0,
     )

--- a/glue_k3d/viewers/common/viewer.py
+++ b/glue_k3d/viewers/common/viewer.py
@@ -1,11 +1,9 @@
-from glue.config import settings
 from glue_jupyter.view import IPyWidgetView
 
-from k3d.factory import plot, points
 from IPython.display import display
 from ipywidgets import HTML
 
-from glue_k3d.common.figure import create_plot, grid_bounds
+from glue_k3d.common.figure import create_plot
 from glue_k3d.utils import to_hex_int
 
 


### PR DESCRIPTION
This PR hides the "axes helper" widget that appears in the bottom-right of the K3D plot.
