### PR TITLE
Update dependency versions, update states and style widgets

### DIFF
--- a/glue_k3d/viewers/scatter/layer_state_widget.py
+++ b/glue_k3d/viewers/scatter/layer_state_widget.py
@@ -1,46 +1,20 @@
-from ipywidgets import FloatSlider, VBox
-from glue_jupyter.link import link
-from glue_jupyter.widgets import LinkedDropdown, Color, Size
+import ipyvuetify as v
 
-class Scatter3DLayerStateWidget(VBox):
+from echo.vue import autoconnect_callbacks_to_vue
+from glue_jupyter.vuetify_helpers import cmap_extras
+
+
+__all__ = ['Scatter3DLayerStateWidget']
+
+
+class Scatter3DLayerStateWidget(v.VuetifyTemplate):
+
+    template_file = (__file__, "layer_style_widget.vue")
 
     def __init__(self, layer_state):
+        super().__init__()
 
         self.state = layer_state
 
-        self.widget_opacity = FloatSlider(min=0, max=1, step=0.01, value=self.state.alpha, description="Opacity")
-        link((self.state, 'alpha'), (self.widget_opacity, 'value'))
-
-        self.widget_shader = LinkedDropdown(self.state, 'shader', label="Shader")
-        link((self.state, 'shader'), (self.widget_shader, 'value'))
-
-        self.widget_size = Size(state=self.state)
-        self.widget_color = Color(state=self.state, color_mode_attr="cmap_mode")
-
-        # self.widget_shininess = FloatSlider(min=0, max=100, value=self.state.shininess, label="Shininess")
-        # link((self.state, 'shininess'), (self.widget_shininess, 'value'))
-
-        # self.widget_mesh_detail = IntSlider(min=0, max=10, value=self.state.mesh_detail, label="Mesh Detail")
-        # link((self.state, 'mesh_detail'), (self.widget_mesh_detail, 'value'))
-        # vector/quivers
-        # self.widget_vector = Checkbox(description='show vectors', value=self.state.vector_visible)
-
-        # self.widget_vector_x = LinkedDropdown(self.state, 'vx_att', label='vx')
-        # self.widget_vector_y = LinkedDropdown(self.state, 'vy_att', label='vy')
-        # self.widget_vector_z = LinkedDropdown(self.state, 'vz_att', label='vz')
-
-        # link((self.state, 'vector_visible'), (self.widget_vector, 'value'))
-        # dlink((self.widget_vector, 'value'), (self.widget_vector_x.layout, 'display'),
-        #       lambda value: None if value else 'none')
-        # dlink((self.widget_vector, 'value'), (self.widget_vector_y.layout, 'display'),
-        #       lambda value: None if value else 'none')
-        # dlink((self.widget_vector, 'value'), (self.widget_vector_z.layout, 'display'),
-        #       lambda value: None if value else 'none')
-
-        # link((self.state, 'vector_visible'), (self.widget_vector, 'value'))
-
-        super().__init__([self.widget_opacity, self.widget_shader,
-                          self.widget_size, self.widget_color])
-                         # self.widget_shininess, self.widget_mesh_detail])
-                         # self.widget_vector, self.widget_vector_x,
-                         # self.widget_vector_y, self.widget_vector_z])
+        extras = {"cmap": cmap_extras(self)}
+        autoconnect_callbacks_to_vue(layer_state, self, extras=extras)

--- a/glue_k3d/viewers/scatter/layer_state_widget.py
+++ b/glue_k3d/viewers/scatter/layer_state_widget.py
@@ -15,7 +15,7 @@ class Scatter3DLayerStateWidget(VBox):
         link((self.state, 'shader'), (self.widget_shader, 'value'))
 
         self.widget_size = Size(state=self.state)
-        self.widget_color = Color(state=self.state)
+        self.widget_color = Color(state=self.state, color_mode_attr="cmap_mode")
 
         # self.widget_shininess = FloatSlider(min=0, max=100, value=self.state.shininess, label="Shininess")
         # link((self.state, 'shininess'), (self.widget_shininess, 'value'))

--- a/glue_k3d/viewers/scatter/layer_style_widget.vue
+++ b/glue_k3d/viewers/scatter/layer_style_widget.vue
@@ -1,0 +1,55 @@
+<template>
+    <div class="glue-layer-scatter">
+        <div class="text-subtitle-2 font-weight-bold">Color</div>
+        <div>
+            <v-select label="color" :items="cmap_mode_items" v-model="cmap_mode_selected" hide-details />
+        </div>
+        <template v-if="(cmap_mode_items[cmap_mode_selected] || {}).text === 'Linear'">
+            <div>
+                <v-select label="attribute" :items="cmap_att_items" v-model="cmap_att_selected" hide-details />
+            </div>
+            <div>
+                <glue-float-field label="min" :value.sync="cmap_vmin" echo-type="float" />
+            </div>
+            <div>
+                <glue-float-field label="max" :value.sync="cmap_vmax" echo-type="float" />
+            </div>
+            <div>
+                <v-select label="colormap" :items="cmap_items" v-model="cmap" hide-details />
+            </div>
+        </template>
+        <div>
+            <v-subheader class="pl-0 slider-label">opacity</v-subheader>
+            <glue-throttled-slider wait="300" min="0" max="1" step="0.01" :value.sync="alpha" echo-type="float" hide-details />
+        </div>
+        <div>
+            <v-select label="shader" :items="shader_items" v-model="shader_selected" />
+        </div>
+        <div class="text-subtitle-2 font-weight-bold">Points</div>
+        <v-select label="size" :items="size_mode_items" v-model="size_mode_selected" hide-details />
+        <template v-if="(size_mode_items[size_mode_selected] || {}).text === 'Linear'">
+            <div>
+                <v-select label="attribute" :items="size_att_items" v-model="size_att_selected" hide-details />
+            </div>
+            <div>
+                <glue-float-field label="min" :value.sync="size_vmin" echo-type="float" />
+            </div>
+            <div>
+                <glue-float-field label="max" :value.sync="size_vmax" echo-type="float" />
+            </div>
+        </template>
+        <div>
+            <v-subheader class="pl-0 slider-label">size scaling</v-subheader>
+            <glue-throttled-slider wait="300" min="0.1" max="10" step="0.01" :value.sync="size_scaling" echo-type="float"
+                hide-details />
+        </div>
+    </div>
+</template>
+
+<style id="layer_scatter">
+.glue-layer-scatter .v-subheader.slider-label {
+    font-size: 12px;
+    height: 16px;
+    margin-top: 6px;
+}
+</style>

--- a/glue_k3d/viewers/scatter/viewer.py
+++ b/glue_k3d/viewers/scatter/viewer.py
@@ -1,5 +1,5 @@
 from echo import CallbackProperty
-from glue_jupyter.common.state3d import Scatter3DViewerState
+from glue.viewers.scatter3d.viewer_state import ScatterViewerState3D
 from glue_vispy_viewers.scatter.jupyter.viewer_state_widget import Scatter3DViewerStateWidget
 
 from glue_k3d.viewers.common.viewer import K3DBaseView
@@ -7,7 +7,7 @@ from glue_k3d.viewers.scatter.layer_artist import K3DScatterLayerArtist
 from glue_k3d.viewers.scatter.layer_state_widget import Scatter3DLayerStateWidget
 
 
-class K3DScatterViewerState(Scatter3DViewerState):
+class K3DScatterViewerState(ScatterViewerState3D):
     visible_grid = CallbackProperty(True) 
 
 

--- a/glue_k3d/viewers/volume/layer_artist.py
+++ b/glue_k3d/viewers/volume/layer_artist.py
@@ -92,7 +92,6 @@ class K3DVolumeLayerArtist(LayerArtist):
             else:
                 self.volume.color_map = linear_color_map(self.state.cmap)
 
-
     def _update_visual_attributes(self, changed, force=False):
 
         if not self.enabled:

--- a/glue_k3d/viewers/volume/layer_state_widget.py
+++ b/glue_k3d/viewers/volume/layer_state_widget.py
@@ -1,11 +1,11 @@
 import ipyvuetify as v
 import traitlets
 
+from echo.vue import autoconnect_callbacks_to_vue
 from glue.config import colormaps
-from glue.core.subset import Subset
+from glue.core import Subset
 
-from glue_jupyter.state_traitlets_helpers import GlueState
-from glue_jupyter.vuetify_helpers import link_glue_choices
+from glue_jupyter.vuetify_helpers import cmap_extras
 
 __all__ = ["K3DVolumeLayerStateWidget"]
 
@@ -14,38 +14,21 @@ class K3DVolumeLayerStateWidget(v.VuetifyTemplate):
 
     template_file = (__file__, "layer_state_widget.vue")
 
-    glue_state = GlueState().tag(sync=True)
-
-    attribute_items = traitlets.List().tag(sync=True)
-    attribute_selected = traitlets.Int(allow_none=True).tag(sync=True)
-
-    # Color
-
-    cmap_mode_items = traitlets.List().tag(sync=True)
-    cmap_mode_selected = traitlets.Int(allow_none=True).tag(sync=True)
-
-    cmap_items = traitlets.List().tag(sync=True)
-
     subset = traitlets.Bool().tag(sync=True)
 
     def __init__(self, layer_state):
         super().__init__()
 
         self.layer_state = layer_state
-        self.glue_state = layer_state
 
         self.subset = isinstance(layer_state.layer, Subset)
 
-        link_glue_choices(self, layer_state, "attribute")
-        link_glue_choices(self, layer_state, "cmap_mode")
-
-        self.cmap_items = [
-            {"text": cmap[0], "value": cmap[1].name} for cmap in colormaps.members
-        ]
-
-        # TODO: We shouldn't need this, but without it the colormap isn' set
+        # TODO: We shouldn't need this, but without it the colormap isn't set
         # when we change to linear mode. Why?
         self.layer_state.cmap = colormaps.members[0][1]
+
+        extras = {"cmap": cmap_extras(self)}
+        autoconnect_callbacks_to_vue(layer_state, self, extras=extras)
 
     def vue_set_colormap(self, data):
         cmap = None

--- a/glue_k3d/viewers/volume/layer_state_widget.vue
+++ b/glue_k3d/viewers/volume/layer_state_widget.vue
@@ -3,9 +3,9 @@
         <div>
             <v-select label="attribute" :items="attribute_items" v-model="attribute_selected" hide-details class="margin-bottom: 16px" />
         </div>
-        <template v-if="glue_state.cmap_mode === 'Linear'">
+        <template v-if="(cmap_mode_items[cmap_mode_selected] || {}).text === 'Linear'">
           <div>
-              <v-select label="colormap" :items="cmap_items" :value="glue_state.cmap" @change="set_colormap" hide-details/>
+              <v-select label="colormap" :items="cmap_items" :value="cmap" @change="set_colormap" hide-details/>
           </div>
         </template>
         <div v-if="!subset">
@@ -13,25 +13,17 @@
         </div>
         <div>
             <v-subheader class="pl-0 slider-label">opacity</v-subheader>
-            <glue-throttled-slider wait="300" max="1" step="0.01" :value.sync="glue_state.alpha" hide-details />
+            <glue-throttled-slider wait="300" max="1" step="0.01" :value.sync="alpha" echo-type="float" hide-details />
         </div>
         <div>
-            <glue-float-field label="min" :value.sync="glue_state.vmin" />
+            <glue-float-field label="min" :value.sync="vmin" echo-type="float" />
         </div>
         <div>
-            <glue-float-field label="max" :value.sync="glue_state.vmax" />
+            <glue-float-field label="max" :value.sync="vmax" echo-type="float" />
         </div>
     </div>
 </template>
-<script>
-    modules.export = {
-        methods: {
-            setAlpha(value) {
-                this.glue_state.alpha = value;
-            },
-        },
-    }
-</script>
+
 <style id="layer_volume">
     .v-subheader.slider-label {
         font-size: 12px;

--- a/glue_k3d/viewers/volume/viewer.py
+++ b/glue_k3d/viewers/volume/viewer.py
@@ -3,7 +3,7 @@ from numpy import argsort
 from echo import CallbackProperty, SelectionCallbackProperty
 from glue.core.data import BaseData
 from glue.core.data_combo_helper import ManualDataComboHelper
-from glue_jupyter.common.state3d import VolumeViewerState
+from glue.viewers.volume3d.viewer_state import VolumeViewerState3D
 
 from glue_k3d.viewers.common.viewer import K3DBaseView
 from glue_k3d.viewers.scatter.viewer import Scatter3DLayerStateWidget
@@ -13,86 +13,9 @@ from glue_k3d.viewers.volume.layer_state_widget import K3DVolumeLayerStateWidget
 from glue_k3d.viewers.volume.viewer_state_widget import K3DVolumeViewerStateWidget
 
 
-class K3DVolumeViewerState(VolumeViewerState):
+class K3DVolumeViewerState(VolumeViewerState3D):
 
     visible_grid = CallbackProperty(True)
-    resolution = CallbackProperty(256)
-    reference_data = SelectionCallbackProperty(docstring='The dataset that is used to define the '
-                                                         'available pixel/world components, and '
-                                                         'which defines the coordinate frame in '
-                                                         'which the images are shown')
-
-    def __init__(self, **kwargs):
-        super().__init__(**kwargs)
-
-        self.add_callback('layers', self._layers_changed, echo_old=True)
-        self.add_callback('x_att', self._on_xatt_changed, echo_old=True)
-        self.add_callback('y_att', self._on_yatt_changed, echo_old=True)
-        self.add_callback('z_att', self._on_zatt_changed, echo_old=True)
-
-        self.ref_data_helper = ManualDataComboHelper(self, 'reference_data')
-        self._layers_changed(None, self.layers)
-
-    def _layers_changed(self, old_layers, new_layers):
-        if self.reference_data is not None and old_layers == new_layers:
-            return
-        self._update_combo_ref_data()
-        self._set_reference_data()
-        self._update_attributes()
-
-    def _update_combo_ref_data(self, *args):
-        self.ref_data_helper.set_multiple_data(self.layers_data)
-
-    def _set_reference_data(self, *args):
-        if self.reference_data is None:
-            self.slices = ()
-            for layer in self.layers:
-                if isinstance(layer.layer, BaseData):
-                    self.reference_data = layer.layer
-                    return
-        else:
-            self.slices = (0,) * self.reference_data.ndim
-
-    @property
-    def numpy_slice_permutation(self):
-        if self.reference_data is None:
-            return None, None
-
-        slices = []
-        coord_att_axes = [self.x_att.axis, self.y_att.axis, self.z_att.axis]
-        for i in range(self.reference_data.ndim):
-            if i in coord_att_axes:
-                slices.append(slice(None))
-            else:
-                if isinstance(self.slices[i], AggregateSlice):
-                    slices.append(self.slices[i].slice)
-                else:
-                    slices.append(self.slices[i])
-
-        axes_order = argsort(coord_att_axes)
-        perm = [0] * len(axes_order)
-        for i, t in enumerate(axes_order):
-            perm[t] = i
-        perm = [perm[2], perm[1], perm[0]]
-        return slices, perm
-
-    def _on_xatt_changed(self, prev_att, new_att):
-        if self.y_att == new_att:
-            self.y_att = prev_att
-        elif self.z_att == new_att:
-            self.z_att = prev_att
-
-    def _on_yatt_changed(self, prev_att, new_att):
-        if self.x_att == new_att:
-            self.x_att = prev_att
-        elif self.z_att == new_att:
-            self.z_att = prev_att
-
-    def _on_zatt_changed(self, prev_att, new_att):
-        if self.x_att == new_att:
-            self.x_att = prev_att
-        elif self.y_att == new_att:
-            self.y_att = prev_att
 
 
 class K3DVolumeView(K3DBaseView):

--- a/glue_k3d/viewers/volume/viewer_state_widget.py
+++ b/glue_k3d/viewers/volume/viewer_state_widget.py
@@ -1,35 +1,17 @@
-from glue_jupyter.state_traitlets_helpers import GlueState
-from glue_jupyter.vuetify_helpers import link_glue_choices
 import ipyvuetify as v
-import traitlets
+
+from echo.vue import autoconnect_callbacks_to_vue
 
 
 class K3DVolumeViewerStateWidget(v.VuetifyTemplate):
 
     template_file = (__file__, "viewer_state_widget.vue")
 
-    glue_state = GlueState().tag(sync=True)
-
-    x_att_items = traitlets.List().tag(sync=True)
-    x_att_selected = traitlets.Int(allow_none=True).tag(sync=True)
-
-    y_att_items = traitlets.List().tag(sync=True)
-    y_att_selected = traitlets.Int(allow_none=True).tag(sync=True)
-
-    z_att_items = traitlets.List().tag(sync=True)
-    z_att_selected = traitlets.Int(allow_none=True).tag(sync=True)
-
-    reference_data_items = traitlets.List().tag(sync=True)
-    reference_data_selected = traitlets.Int(allow_none=True).tag(sync=True)
-
     def __init__(self, viewer_state):
 
         super().__init__()
 
         self.viewer_state = viewer_state
-        self.glue_state = viewer_state
 
-        link_glue_choices(self, viewer_state, "x_att")
-        link_glue_choices(self, viewer_state, "y_att")
-        link_glue_choices(self, viewer_state, "z_att")
-        link_glue_choices(self, viewer_state, "reference_data")
+        extras = {"resolution": "selection"}
+        autoconnect_callbacks_to_vue(viewer_state, self, extras=extras)

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,6 +14,7 @@ zip_safe = False
 python_requires = >=3.10
 packages = find:
 install_requires =
+    echo>=0.15.0
     glue-core>=1.25.0
     glue-jupyter
     k3d

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,6 +14,7 @@ zip_safe = False
 python_requires = >=3.10
 packages = find:
 install_requires =
+    glue-core>=1.25.0
     glue-jupyter
     k3d
     beautifulsoup4


### PR DESCRIPTION
This PR updates our pins on `glue-core` and `echo`, which lets us update our state objects and style widgets to use the 3D state classes that are now in `glue-core` and the Vue autoconnections from `echo.vue`.